### PR TITLE
add logout support for hyprland session

### DIFF
--- a/configs/waybar/scripts/power-menu/powermenu.sh
+++ b/configs/waybar/scripts/power-menu/powermenu.sh
@@ -69,6 +69,8 @@ run_cmd() {
 				i3-msg exit
 			elif [[ "$DESKTOP_SESSION" == 'plasma' ]]; then
 				qdbus org.kde.ksmserver /KSMServer logout 0 0 0
+			elif [[ "$DESKTOP_SESSION" == 'hyprland' ]]; then
+				hyprctl dispatch exit
 			fi
 		fi
 	else


### PR DESCRIPTION
When logged in a hyprland session, the logout command issued by the custom power-menu waybar icon does not work.