### PR TITLE
fix: "decoration:blur" is invalid

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -75,10 +75,12 @@ general {
 
 decoration {
     rounding=18
-    blur=1
-    blur_size=6.8 # minimum 1
-    blur_passes=2 # minimum 1, more passes = more resource intensive.
-    blur_new_optimizations = true   
+    blur {
+      enabled=true
+      size=6.8 # minimum 1
+      passes=2 # minimum 1, more passes = more resource intensive.
+      new_optimizations = true
+    }
     # Your blur "amount" is blur_size * blur_passes, but high blur_size (over around 5-ish) will produce artifacts.
     # if you want heavy blur, you need to up the blur_passes.
     # the more passes, the more you can up the blur_size without noticing artifacts.


### PR DESCRIPTION
I used your configuration to get started with hyprland, thanks for the amazing work!

I'm opening this pull request because there was just something that did not worked on the dotfiles:

- Looks like using "blur_anything_here"  is not allowed inside decoration (maybe it was a recent change, I look up on that but found nothing), following is the [hyprland wiki](https://wiki.hyprland.org/Configuring/Variables/#blur) about the rule:

![image](https://github.com/1amSimp1e/dots/assets/55422938/0faac523-42b0-41d1-b037-127e40376f17)

- The error message on my local:

![image](https://github.com/1amSimp1e/dots/assets/55422938/f295565c-7dca-4078-ba6d-5b12b8763c67)

If it's not an error and I'm doing something wrong let me know, I started with hyprland today. Thanks!